### PR TITLE
 Fix build

### DIFF
--- a/Movim/build.gradle
+++ b/Movim/build.gradle
@@ -2,12 +2,13 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "28.0.0"
 
     defaultConfig {
         applicationId "com.movim.movim"
         minSdkVersion 21
-        targetSdkVersion 21
+        targetSdkVersion 26
+        versionCode 12
+        versionName "0.17.0.0"
     }
 
     buildTypes {

--- a/Movim/src/main/AndroidManifest.xml
+++ b/Movim/src/main/AndroidManifest.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.movim.movim"
-    android:versionCode="12"
-    android:versionName="0.17.0.0">
-
-    <uses-sdk
-        android:minSdkVersion="21"
-        android:targetSdkVersion="26" />
+    package="com.movim.movim">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />


### PR DESCRIPTION
...else this fails with

```
WARNING: The specified Android SDK Build Tools version (28.0.0) is ignored, as it is below the minimum supported version (28.0.3) for Android Gradle Plugin 3.6.1.
Android SDK Build Tools 28.0.3 will be used.
To suppress this warning, remove "buildToolsVersion '28.0.0'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.
...
* What went wrong:
Execution failed for task ':Movim:lintVitalRelease'.
> Lint infrastructure error
  Caused by: java.lang.reflect.InvocationTargetException
...
  Caused by: com.android.builder.errors.EvalIssueException: Failed to parse XML in /home/strech/fdroiddata/build/com.movim.movim/Movim/src/main/AndroidManifest.xml
  The minSdk version should not be declared in the android manifest file. You can move the version from the manifest to the defaultConfig in the build.gradle file.
...
```
